### PR TITLE
Fixing a typographic issue in paper abstract

### DIFF
--- a/_posts/2021-07-01-jiang21b.md
+++ b/_posts/2021-07-01-jiang21b.md
@@ -12,8 +12,8 @@ abstract: Environments with procedurally generated content serve as important be
   effectively estimate a level’s future learning potential and, when used to guide
   the sampling procedure, induce an emergent curriculum of increasingly difficult
   levels. By adapting the sampling of training levels, PLR significantly improves
-  sample-efficiency and generalization on Procgen Benchmark{—}matching the previous
-  state-of-the-art in test return{—}and readily combines with other methods. Combined
+  sample-efficiency and generalization on Procgen Benchmark—matching the previous
+  state-of-the-art in test return—and readily combines with other methods. Combined
   with the previous leading method, PLR raises the state-of-the-art to over 76% improvement
   in test return relative to standard RL baselines.
 layout: inproceedings


### PR DESCRIPTION
This change simply removes the extraneous {} braces surrounding the '—' character in the abstract for 2021-07-01-jiang21b.md.