### PR TITLE
Update 2021-07-01-mora21a.md

### DIFF
--- a/_posts/2021-07-01-mora21a.md
+++ b/_posts/2021-07-01-mora21a.md
@@ -26,12 +26,12 @@ lastpage: 7817
 page: 7805-7817
 order: 7805
 cycles: false
-bibtex_author: Mora, Miguel Angel Zamora and Peychev, Momchil P and Ha, Sehoon and
+bibtex_author: Mora, Miguel Angel Zamora and Peychev, Momchil and Ha, Sehoon and
   Vechev, Martin and Coros, Stelian
 author:
 - given: Miguel Angel Zamora
   family: Mora
-- given: Momchil P
+- given: Momchil
   family: Peychev
 - given: Sehoon
   family: Ha


### PR DESCRIPTION
Remove middle initial

I would not like to have my middle initial included in the author names (so that it is consistent with my name in the pdf). I was not aware that this information gets linked from e.g. CMT, I assume.