### PR TITLE
FIX: Minor typo fix in title of 2021-07-01-graf21a.md

### DIFF
--- a/_posts/2021-07-01-graf21a.md
+++ b/_posts/2021-07-01-graf21a.md
@@ -1,5 +1,5 @@
 ---
-title: Dissecting Supervised Constrastive Learning
+title: Dissecting Supervised Contrastive Learning
 abstract: Minimizing cross-entropy over the softmax scores of a linear map composed
   with a high-capacity encoder is arguably the most popular choice for training neural
   networks on supervised learning tasks. However, recent works show that one can directly
@@ -22,7 +22,7 @@ publisher: PMLR
 issn: 2640-3498
 id: graf21a
 month: 0
-tex_title: Dissecting Supervised Constrastive Learning
+tex_title: Dissecting Supervised Contrastive Learning
 firstpage: 3821
 lastpage: 3830
 page: 3821-3830


### PR DESCRIPTION
This patch fixes a minor typo in the title of the ICML paper "Dissecting Supervised Contrastive Learning" (I, Roland Kwitt, am co-author of that paper).