### PR TITLE
Update 2021-07-01-nemecek21a.md

### DIFF
--- a/_posts/2021-07-01-nemecek21a.md
+++ b/_posts/2021-07-01-nemecek21a.md
@@ -23,11 +23,11 @@ lastpage: 8033
 page: 8025-8033
 order: 8025
 cycles: false
-bibtex_author: Nemecek, Mark W and Parr, Ron
+bibtex_author: Nemecek, Mark and Parr, Ronald
 author:
-- given: Mark W
+- given: Mark
   family: Nemecek
-- given: Ron
+- given: Ronald
   family: Parr
 date: 2021-07-01
 address:


### PR DESCRIPTION
Remove the first author's middle initial and use the second author's full first name (as in the PDF).