### PR TITLE
Fix names

### DIFF
--- a/_posts/2021-07-01-beani21a.md
+++ b/_posts/2021-07-01-beani21a.md
@@ -28,11 +28,11 @@ lastpage: 758
 page: 748-758
 order: 748
 cycles: false
-bibtex_author: Beani, Dominique and Passaro, Saro and L{\'e}tourneau, Vincent and
+bibtex_author: Beaini, Dominique and Passaro, Saro and L{\'e}tourneau, Vincent and
   Hamilton, Will and Corso, Gabriele and Li{\'o}, Pietro
 author:
 - given: Dominique
-  family: Beani
+  family: Beaini
 - given: Saro
   family: Passaro
 - given: Vincent

--- a/_posts/2021-07-01-zbontar21a.md
+++ b/_posts/2021-07-01-zbontar21a.md
@@ -30,7 +30,7 @@ lastpage: 12320
 page: 12310-12320
 order: 12310
 cycles: false
-bibtex_author: Zbontar, Jure and Jing, Li and Misra, Ishan and Lecun, Yann and Deny,
+bibtex_author: Zbontar, Jure and Jing, Li and Misra, Ishan and LeCun, Yann and Deny,
   Stephane
 author:
 - given: Jure
@@ -40,7 +40,7 @@ author:
 - given: Ishan
   family: Misra
 - given: Yann
-  family: Lecun
+  family: LeCun
 - given: Stephane
   family: Deny
 date: 2021-07-01


### PR DESCRIPTION
By chance, I found a minor typo for Yann LeCun. 

I also tries to resolve #16.

If I should replace `beani21a` with `beaini21a`, I'm happy to update the following filenames:

```bash
$ tree -f |  grep -i beani
│   ├── ./_posts/2021-07-01-beani21a.md
├── ./beani21a
│   ├── ./beani21a/beani21a-supp.pdf
│   └── ./beani21a/beani21a.pdf
│   ├── ./v139Permissions/beani21aPermission.pdf
```


